### PR TITLE
design: system chat level별 색깔 부여

### DIFF
--- a/src/components/lobby/LobbyChatSystem.tsx
+++ b/src/components/lobby/LobbyChatSystem.tsx
@@ -7,16 +7,19 @@ interface LobbyChatSystemProps {
 }
 
 const LobbyChatSystem: FC<LobbyChatSystemProps> = ({ level, content }) => {
-  return (
-    <LobbyChatSystemStyle>
-      {level} : {content}
-    </LobbyChatSystemStyle>
-  );
+  return <LobbyChatSystemStyle level={level}>{content}</LobbyChatSystemStyle>;
 };
 
 export default LobbyChatSystem;
 
-const LobbyChatSystemStyle = styled.div`
+const LobbyChatSystemStyle = styled.div<{ level: string }>`
+  color: ${(props) => getColorByLevel(props.level)};
   font-weight: 600;
-  color: #eb6d6d;
+  margin-bottom: 10px;
 `;
+
+function getColorByLevel(level: string) {
+  if (level === "info") return "#464444";
+  else if (level === "error") return "#940606";
+  else return "#abab21";
+}


### PR DESCRIPTION
1. System Chat에서 Level: content 형식에서 content만 표시

2. System Chat Level 별 색깔 변경
- error: 빨강 계열
- warning: 노랑 계열
- info: 검정 계열

![image](https://user-images.githubusercontent.com/110733523/201898566-5f526150-18af-400f-be27-e5b80aa2b935.png)
